### PR TITLE
fix #16: Change hardcoded `vscode-resouce` to use webview

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,12 +175,10 @@ class WaveformRenderPanel {
     );
 
     // And the uri we use to load this script in the webview
-    const scriptUri = scriptPathOnDisk.with({ scheme: "vscode-resource" });
-    const defaultUri = defaultSkinPathOnDisk.with({
-      scheme: "vscode-resource",
-    });
-    const narrowUri = narrowSkinPathOnDisk.with({ scheme: "vscode-resource" });
-    const lowkeyUri = lowkeySkinPathOnDisk.with({ scheme: "vscode-resource" });
+    const scriptUri = this._panel.webview.asWebviewUri(scriptPathOnDisk);
+    const defaultUri = this._panel.webview.asWebviewUri(defaultSkinPathOnDisk);
+    const narrowUri = this._panel.webview.asWebviewUri(narrowSkinPathOnDisk);
+    const lowkeyUri = this._panel.webview.asWebviewUri(lowkeySkinPathOnDisk);
 
     return `<!DOCTYPE html>
             <html lang="en">


### PR DESCRIPTION
I believe the root cause of issue #16 is described in https://github.com/microsoft/vscode/issues/97962. 
I made the recommended changes and tested this locally with vscode v1.73.1 and I am now able to view the rendered waveforms. 