### PR TITLE
Dev/live preview button

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
     "url": "https://github.com/bmpenuelas/waveform-render-vscode.git"
   },
   "activationEvents": [
-    "onCommand:waveformRender.start",
-    "onCommand:waveformRender.toggleLivePreview",
     "onWebviewPanel:waveformRender"
   ],
   "main": "./out/extension.js",
@@ -42,10 +40,31 @@
       },
       {
         "command": "waveformRender.toggleLivePreview",
-        "title": "Toggle Live Preview",
-        "category": "Waveform Render"
+        "title": "Toggle Live Waveform Preview",
+        "category": "Waveform Render",
+        "icon": "$(pulse)"
       }
     ],
+    "menus": {
+      "editor/title": [
+        {
+          "command": "waveformRender.toggleLivePreview",
+          "group": "navigation",
+          "when": "resourceExtname == .json"
+        }
+      ]
+    },
+    "configuration": {
+      "type": "object",
+      "title": "Waveform Render Settings",
+      "properties": {
+        "waveformRender.closePanelOnDisable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Close the Waveform panel when live preview is disabled."
+        }
+      }
+    },
     "keybindings": [
       {
         "command": "waveformRender.start",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 function getTitle() {
   return (
-    "Waveform Render: " +
+    "Waveform Blabla: " +
     vscode.window.activeTextEditor.document.fileName
       .split("\\")
       .pop()
@@ -62,8 +62,15 @@ class WaveformRenderPanel {
   private _disposables: vscode.Disposable[] = [];
 
   public static toggleLivePreview(extensionPath: string) {
+    const closePanelOnDisable = vscode.workspace.getConfiguration("waveformRender").get<boolean>("closePanelOnDisable", true);
+
     if (WaveformRenderPanel.livePreview) {
       WaveformRenderPanel.disableLivePreview();
+
+      // Close the panel if the setting is enabled
+      if (closePanelOnDisable && WaveformRenderPanel.currentPanel) {
+        WaveformRenderPanel.currentPanel.dispose();
+      }
     } else {
       WaveformRenderPanel.livePreviewDocumentPath =
         vscode.window.activeTextEditor.document.uri.path;


### PR DESCRIPTION
Added a button to toggle Live preview:
![image](https://github.com/user-attachments/assets/fa13debf-661a-45dd-9e2f-796005930a2a)

And added an option to automatically close the panel when disabling live preview (this is disabled by default to preserve the old behavior):
![image](https://github.com/user-attachments/assets/706b4b03-2189-45be-a91c-25b4129dd572)